### PR TITLE
Add DockerDown command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,14 @@ make assumptions about how you work.
       desc = "Bring up the DevContainer",
     },
     {
-      "<leader>Dc",
+      "<leader>Dd",
       ":DevcontainerConnect<CR>",
       desc = "Connect to DevContainer",
+    },
+    {
+      "<leader>Dc",
+      ":DevcontainerDown<CR>",
+      desc = "Kill the current DevContainer",
     },
     {
       "<leader>De",

--- a/lua/devcontainer-cli/devcontainer_cli.lua
+++ b/lua/devcontainer-cli/devcontainer_cli.lua
@@ -72,4 +72,9 @@ function M.connect()
   vim.cmd("wqa")
 end
 
+-- kill the current running docker container associated with the current project
+function M.down()
+  utils.down()
+end
+
 return M

--- a/lua/devcontainer-cli/init.lua
+++ b/lua/devcontainer-cli/init.lua
@@ -69,6 +69,15 @@ function M.setup(opts)
     }
   )
 
+  vim.api.nvim_create_user_command(
+    "DevcontainerDown",
+    devcontainer_cli.down,
+    {
+      nargs = 0,
+      desc = "Kill the current devcontainer.",
+    }
+  )
+
   log.debug("Finished setting up devcontainer-cli")
 end
 

--- a/lua/devcontainer-cli/log.lua
+++ b/lua/devcontainer-cli/log.lua
@@ -20,8 +20,10 @@ local default_config = {
   -- Should write to a file
   use_file = true,
 
-  -- Any messages above this level will be logged.
-  level = "debug",
+  -- Any messages above this level will be logged to log file.
+  log_level = "debug",
+  -- Any messages above this level will be logged to console.
+  console_level = "info",
 
   -- Level configuration
   modes = {
@@ -85,10 +87,6 @@ log.new = function(config, standalone)
 
 
   local log_at_level = function(level, level_config, message_maker, ...)
-    -- Return early if we're below the config.level
-    if level < levels[config.level] then
-      return
-    end
     local nameupper = level_config.name:upper()
 
     local msg = message_maker(...)
@@ -96,7 +94,7 @@ log.new = function(config, standalone)
     local lineinfo = info.short_src .. ":" .. info.currentline
 
     -- Output to console
-    if config.use_console then
+    if config.use_console and level < levels[config.console_level] then
       local console_string = string.format(
       "[%-6s%s] %s: %s",
       nameupper,
@@ -120,7 +118,7 @@ log.new = function(config, standalone)
     end
 
     -- Output to log file
-    if config.use_file then
+    if config.use_file and level < levels[config.log_level] then
       local fp = io.open(outfile, "a")
       local str = string.format("[%-6s%s] %s: %s\n",
       nameupper, os.date(), lineinfo, msg)

--- a/lua/devcontainer-cli/terminal.lua
+++ b/lua/devcontainer-cli/terminal.lua
@@ -32,7 +32,7 @@ local _on_fail     = function(exit_code)
 end
 
 local _on_success  = function()
-  log.INFO("Devcontainer process succeeded!")
+  log.info("Devcontainer process succeeded!")
 end
 
 -- on_exit callback function to delete the open buffer when devcontainer exits


### PR DESCRIPTION
Using `docker ps` it is possible to obtain the `pid` of a docker container. `devcontainer-cli` uses the `devcontainer.json` path as a label for a devcontainer. With these two bits of information we are able to kill a currently running devcontainer.

Fixes: #5 