### PR TITLE
Add help for DevcontainerDown and config for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,18 @@ make assumptions about how you work.
       dotfiles_repository = "https://github.com/erichlf/dotfiles.git",
       dotfiles_branch = "devcontainer-cli", -- branch to clone from dotfiles_repository`
       dotfiles_targetPath = "~/dotfiles", -- location to install dotfiles
-      dotfiles_intallCommand = "install.sh", -- script to run after dotfiles are cloned
+      -- script to run after dotfiles are cloned
+      dotfiles_intallCommand = "install.sh", 
       shell = "bash", -- shell to use when executing commands
       -- The particular binary to use for connecting to in the devcontainer
       -- Most likely this should remain nvim
       nvim_binary = "nvim",
+      -- Set the logging level for console (notifications) and file logging. 
+      -- The available levels are trace, debug, info, warn, error, or fatal.
+      -- Set the log level for file logging
+      log_level = "debug",
+      -- Set the log level for console logging
+      console_level = "info",
     }
     require('devcontainer-cli').setup(opts)
   end,

--- a/doc/devcontainer-cli.nvim.txt
+++ b/doc/devcontainer-cli.nvim.txt
@@ -11,8 +11,6 @@ Development is in progress, but the plugin can already be used.
 To find out more:
 https://github.com/erichlf/devcontainer-cli.nvim
 
-  :h DevcontainerUp 
-
 DevcontainerUp                                                  *DevcontainerUp*
     Spawns a devcontainer, installing dotfiles in the docker container.
 
@@ -28,4 +26,7 @@ DevcontainerConnect                                        *DevcontainerConnect*
     Closes the nvim sessions (all sessions fromt the terminal) and opens a new
     terminal which is connected in the docker container, ready to execute the
     nvim inside the docker container and start developing your application.
+
+DevcontainerDown                                              *DevcontainerDown*
+    Stops and removes the devcontainer associated with the current project.
 ================================================================================

--- a/lua/devcontainer-cli/config.lua
+++ b/lua/devcontainer-cli/config.lua
@@ -49,7 +49,11 @@ local default_config = {
   nvim_binary = "nvim",
   -- The shell to use for executing command. Available sh, bash, zsh or any
   -- other that uses '-c' to signify a command is to follow
-  shell = 'bash',
+  shell = "bash",
+  -- Set the log level for file logging
+  log_level = "info",
+  -- Set the log level for console logging
+  console_level = "info",
 }
 
 local options

--- a/lua/devcontainer-cli/log.lua
+++ b/lua/devcontainer-cli/log.lua
@@ -6,6 +6,8 @@
 -- This library is free software; you can redistribute it and/or modify it
 -- under the terms of the MIT license. See LICENSE for details.
 
+global_config = require("devcontainer-cli.config")
+
 -- User configuration section
 local default_config = {
   -- Name of the plugin. Prepended to log messages
@@ -21,9 +23,9 @@ local default_config = {
   use_file = true,
 
   -- Any messages above this level will be logged to log file.
-  log_level = "debug",
+  log_level = global_config.log_level,
   -- Any messages above this level will be logged to console.
-  console_level = "info",
+  console_level = global_config.console_level,
 
   -- Level configuration
   modes = {


### PR DESCRIPTION
`DevcontainerDown` was missing from the help, so this adds it.

Additionally, configs were added so that logging levels could be configured.

Fixes: #23, #22 